### PR TITLE
Upgrade speedtest-official.sh to Speedtest V2.0.2

### DIFF
--- a/scripts/pi-hole/speedtest/speedtest-official.sh
+++ b/scripts/pi-hole/speedtest/speedtest-official.sh
@@ -15,9 +15,9 @@ function nointernet(){
 
 
 if [[ "$serverid" =~ ^[0-9]+$ ]]; then
-    /usr/bin/speedtest -s $serverid --accept-gdpr --accept-license -f json-pretty > /tmp/speedtest.log || nointernet
+    /usr/bin/speedtest -s $serverid --json --share > /tmp/speedtest.log || nointernet
 else
-    /usr/bin/speedtest --accept-gdpr --accept-license -f json-pretty > /tmp/speedtest.log || nointernet
+    /usr/bin/speedtest --json --share > /tmp/speedtest.log || nointernet
 fi
 
 # sed 's/,/./g' fix for those regions use , instead of .
@@ -25,14 +25,14 @@ fi
 FILE=/tmp/speedtest.log
 if [[ -f "$FILE" ]]; then
     stop=$(date +"%Y-%m-%d %H:%M:%S")
-    download=`cat /tmp/speedtest.log| jq -r '.download.bandwidth' | awk '{$1=$1*8/1000/1000; print $1;}' | sed 's/,/./g' `
-    upload=`cat /tmp/speedtest.log| jq -r '.upload.bandwidth' | awk '{$1=$1*8/1000/1000; print $1;}' | sed 's/,/./g'`
+    download=`cat /tmp/speedtest.log| jq -r '.download' | awk '{$1=$1/1000/1000; print $1;}' | sed 's/,/./g' `
+    upload=`cat /tmp/speedtest.log| jq -r '.upload' | awk '{$1=$1/1000/1000; print $1;}' | sed 's/,/./g'`
     server_name=`cat /tmp/speedtest.log| jq -r '.server.name'`
-    isp=`cat /tmp/speedtest.log| jq -r '.isp'`
-    server_ip=`cat /tmp/speedtest.log| jq -r '.server.ip'`
-    from_ip=`cat /tmp/speedtest.log| jq -r '.interface.externalIp'`
-    server_ping=`cat /tmp/speedtest.log| jq -r '.ping.latency'`
-    share_url=`cat /tmp/speedtest.log| jq -r '.result.url'`
+    isp=`cat /tmp/speedtest.log| jq -r '.client.isp'`
+    server_ip=`cat /tmp/speedtest.log| jq -r '.server.host'`
+    from_ip=`cat /tmp/speedtest.log| jq -r '.client.ip'`
+    server_ping=`cat /tmp/speedtest.log| jq -r '.ping'`
+    share_url=`cat /tmp/speedtest.log| jq -r '.share'`
     server_dist=0
 
     rm /tmp/speedtest.log
@@ -47,4 +47,3 @@ if [[ -f "$FILE" ]]; then
 
     sqlite3 /etc/pihole/speedtest.db  "insert into speedtest values (NULL, '${start}', '${stop}', '${isp}', '${from_ip}', '${server_name}', ${server_dist}, ${server_ping}, ${download}, ${upload}, '${share_url}');"
 fi
-

--- a/scripts/pi-hole/speedtest/speedtest-official.sh
+++ b/scripts/pi-hole/speedtest/speedtest-official.sh
@@ -12,12 +12,22 @@ function nointernet(){
     sqlite3 /etc/pihole/speedtest.db  "insert into speedtest values (NULL, '${start}', '${stop}', 'No Internet', '-', '-', 0, 0, 0, 0, '#');"
     exit
 }
+# Get Speedtest-Version
+version=$(echo $(speedtest --version) | grep -oE '[0-9\.]+[ -]*' | head -1 | sed -e 's/^[ \t]*//' -e 's/[ \t]*$//')
+[ -z "$version" ] && version=$(echo "$output" | grep -oE '[0-9\.]+' | head -1)
 
-
-if [[ "$serverid" =~ ^[0-9]+$ ]]; then
-    /usr/bin/speedtest -s $serverid --json --share > /tmp/speedtest.log || nointernet
+if [[ "$version" >= "2.0.0" ]]; then
+    if [[ "$serverid" =~ ^[0-9]+$ ]]; then
+        /usr/bin/speedtest -s $serverid --json --share > /tmp/speedtest.log || nointernet
+    else
+        /usr/bin/speedtest --json --share > /tmp/speedtest.log || nointernet
+    fi
 else
-    /usr/bin/speedtest --json --share > /tmp/speedtest.log || nointernet
+    if [[ "$serverid" =~ ^[0-9]+$ ]]; then
+        /usr/bin/speedtest -s $serverid --accept-gdpr --accept-license -f json-pretty > /tmp/speedtest.log || nointernet
+    else
+        /usr/bin/speedtest --accept-gdpr --accept-license -f json-pretty > /tmp/speedtest.log || nointernet
+    fi
 fi
 
 # sed 's/,/./g' fix for those regions use , instead of .
@@ -25,15 +35,27 @@ fi
 FILE=/tmp/speedtest.log
 if [[ -f "$FILE" ]]; then
     stop=$(date +"%Y-%m-%d %H:%M:%S")
-    download=`cat /tmp/speedtest.log| jq -r '.download' | awk '{$1=$1/1000/1000; print $1;}' | sed 's/,/./g' `
-    upload=`cat /tmp/speedtest.log| jq -r '.upload' | awk '{$1=$1/1000/1000; print $1;}' | sed 's/,/./g'`
     server_name=`cat /tmp/speedtest.log| jq -r '.server.name'`
-    isp=`cat /tmp/speedtest.log| jq -r '.client.isp'`
-    server_ip=`cat /tmp/speedtest.log| jq -r '.server.host'`
-    from_ip=`cat /tmp/speedtest.log| jq -r '.client.ip'`
-    server_ping=`cat /tmp/speedtest.log| jq -r '.ping'`
-    share_url=`cat /tmp/speedtest.log| jq -r '.share'`
     server_dist=0
+    
+    if [[ "$version" >= "2.0.0" ]]; then
+        download=`cat /tmp/speedtest.log| jq -r '.download' | awk '{$1=$1/1000/1000; print $1;}' | sed 's/,/./g' `
+        upload=`cat /tmp/speedtest.log| jq -r '.upload' | awk '{$1=$1/1000/1000; print $1;}' | sed 's/,/./g'`
+        isp=`cat /tmp/speedtest.log| jq -r '.client.isp'`
+        server_ip=`cat /tmp/speedtest.log| jq -r '.server.host'`
+        from_ip=`cat /tmp/speedtest.log| jq -r '.client.ip'`
+        server_ping=`cat /tmp/speedtest.log| jq -r '.ping'`
+        share_url=`cat /tmp/speedtest.log| jq -r '.share'`
+    else
+        download=`cat /tmp/speedtest.log| jq -r '.download.bandwidth' | awk '{$1=$1*8/1000/1000; print $1;}' | sed 's/,/./g' `
+        upload=`cat /tmp/speedtest.log| jq -r '.upload.bandwidth' | awk '{$1=$1*8/1000/1000; print $1;}' | sed 's/,/./g'`
+        isp=`cat /tmp/speedtest.log| jq -r '.isp'`
+        server_ip=`cat /tmp/speedtest.log| jq -r '.server.ip'`
+        from_ip=`cat /tmp/speedtest.log| jq -r '.interface.externalIp'`
+        server_ping=`cat /tmp/speedtest.log| jq -r '.ping.latency'`
+        share_url=`cat /tmp/speedtest.log| jq -r '.result.url'`
+    fi
+    
 
     rm /tmp/speedtest.log
 


### PR DESCRIPTION
Compatibility to Speedtest-Cli 2.0.2
Speedtest 2.0.2 doesn't allow Parameters like `--accept-gdpr --accept-license -f json-pretty`. 
Now we need to use `--json` for Json output and `--share` to generate the Speedtest-Url.

Also the output json changed.